### PR TITLE
Bump version python=3.6, baseimage=0.10.0 and luigi=2.7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.9.22
+FROM phusion/baseimage:0.10.0
 # Use baseimage-docker's init system
 CMD ["/sbin/my_init", "--quiet"]
 
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
 
 # Setup CONDA (https://hub.docker.com/r/continuumio/miniconda3/~/dockerfile/)
 ENV MINICONDA_VERSION latest
-ENV PYTHON_VERSION 3.5
+ENV PYTHON_VERSION 3.6
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     curl -k -o /miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-$MINICONDA_VERSION-Linux-x86_64.sh && \
     /bin/bash /miniconda.sh -b -p /opt/conda && \
@@ -47,7 +47,7 @@ RUN conda install -y \
         && \
     conda clean -a -y
 
-ENV LUIGI_VERSION 2.7.1
+ENV LUIGI_VERSION 2.7.2
 ENV LUIGI_CONFIG_DIR /etc/luigi/
 
 RUN mkdir -p $LUIGI_CONFIG_DIR

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 ## Versions
 
-* `axiom/docker-luigi:latest` (2.7.1)
+* `axiom/docker-luigi:latest` (2.7.2)
+* `axiom/docker-luigi:2.7.2`
 * `axiom/docker-luigi:2.7.1`
 * `axiom/docker-luigi:2.7.0`
 * `axiom/docker-luigi:2.6.2`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-luigi==2.7.1
+luigi==2.7.2
 sqlalchemy


### PR DESCRIPTION
Warning: According to baseimage release notes version 0.10.0 is an API breaking release. Unfortunately I couldn't find any specific details about the API changes. I have a running luigid instance running this fork, so far without any problems.

Is there a specific reason why you are using python 3.5 instead of 3.6?