### PR TITLE
fix volumes in dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update && apt-get install -y \
 
 COPY logging.conf ${LUIGI_CONFIG_DIR}
 COPY luigi.conf ${LUIGI_CONFIG_DIR}
-VOLUME [${LUIGI_CONFIG_DIR}, ${LUIGI_STATE_DIR}]
+VOLUME ["${LUIGI_CONFIG_DIR}", "${LUIGI_STATE_DIR}"]
 
 EXPOSE 8082/TCP
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -32,7 +32,7 @@ RUN apk add --no-cache --virtual .build-deps \
 
 COPY logging.conf ${LUIGI_CONFIG_DIR}
 COPY luigi.conf ${LUIGI_CONFIG_DIR}
-VOLUME [${LUIGI_CONFIG_DIR}, ${LUIGI_STATE_DIR}]
+VOLUME ["${LUIGI_CONFIG_DIR}", "${LUIGI_STATE_DIR}"]
 
 EXPOSE 8082/TCP
 


### PR DESCRIPTION
The paths for VOLUME defined by variables need to be enclosed in quotes otherwise you get brackets in the first and last mount paths in the list.